### PR TITLE
Update class.tx_crawler_scheduler_imAdditionalFieldProvider.php

### DIFF
--- a/scheduler/class.tx_crawler_scheduler_imAdditionalFieldProvider.php
+++ b/scheduler/class.tx_crawler_scheduler_imAdditionalFieldProvider.php
@@ -55,7 +55,8 @@ class tx_crawler_scheduler_imAdditionalFieldProvider implements tx_scheduler_Add
 		if (empty($taskInfo['startPage'])) {
 			if ($schedulerModule->CMD == 'add') {
 				$taskInfo['startPage'] = 0;
-				$task->startPage = 0;
+				if ($task)
+				  $task->startPage = 0;
 			} elseif ($schedulerModule->CMD == 'edit') {
 				$taskInfo['startPage'] = $task->startPage;
 			} else {


### PR DESCRIPTION
Adding new scheduler task in TYPO3 BE didn't show the form. The scheduler called getAdditionalFields() with $task = NULL which lead to an exception. Occured in TYPO3 6.2.6
